### PR TITLE
removed unnessary information in email alerts

### DIFF
--- a/Code/src/web/views/email/_bolo-details.jade
+++ b/Code/src/web/views/email/_bolo-details.jade
@@ -1,3 +1,7 @@
+<!-- 
+I do not believe this is being used anymore since email aesthetics have
+been updated on 3 Jun 2016. JMB
+-->
 h2 #{bolo.category}
 
 table

--- a/Code/src/web/views/email/layout.jade
+++ b/Code/src/web/views/email/layout.jade
@@ -1,4 +1,7 @@
-
+<!--
+I do not believe this is being used anymore since email aesthetics have
+been updated on 3 Jun 2016. JMB
+-->
 block content
 
 

--- a/Code/src/web/views/email/new-bolo-notification.jade
+++ b/Code/src/web/views/email/new-bolo-notification.jade
@@ -1,11 +1,7 @@
-extends ./layout.jade
 
 block content
-    p Hi,
-    p A new 
-        a(href=app_url + '/bolo/details/' + bolo.id ) #{bolo.category} BOLO 
-        | has been recently posted on the BOLO Flier Creator app. 
-        a( href=app_url ) Login 
-        | to view this and other BOLOs.
-
-    include ./_bolo-details.jade
+    p A new&nbsp;
+        a(href=app_url + '/bolo/details/' + bolo.id ) #{bolo.category} BOLO
+        |&nbsp;has been recently posted on the BOLO Flier Creator app.&nbsp;
+        a( href=app_url ) Login
+        |&nbsp;to view this and other BOLOs.

--- a/Code/src/web/views/email/update-bolo-notification.jade
+++ b/Code/src/web/views/email/update-bolo-notification.jade
@@ -1,11 +1,7 @@
-extends ./layout.jade
 
 block content
-    p Hi,
-    p A recent update has been made to a 
-        a( href=app_url + '/bolo/details/' + bolo.id ) #{bolo.category} BOLO 
-        | on the BOLO Flier Creator app. 
-        a( href=app_url ) Login 
-        | to view this and other BOLOs.
-
-    include ./_bolo-details.jade
+    p A recent update has been made to a&nbsp;
+        a( href=app_url + '/bolo/details/' + bolo.id ) #{bolo.category} BOLO
+        |&nbsp;on the BOLO Flier Creator app.&nbsp;
+        a( href=app_url ) Login
+        |&nbsp;to view this and other BOLOs.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-# BOLO Flier Creator Version 4
+# BOLO Flier Creator Version 5
+
+#
+
 
 This project is the fourth iteration of the BOLO Flier Creator application
 conceptualized by the Pinecrest Police Department in Miami, Florida.  The fourth


### PR DESCRIPTION
I worked on the new bolo notification and update bolo notification classes. In both classes I deleted extends ./layout.jade and include ./_bolo-details.jade which eliminates the need for either the layout.jade or bolo-details.jade class. Since at this point I do not believe either layout.jade or bolo-details.jade are being used I commented them to save future programmers time.
