### PR TITLE
Fix issue with routing at login for apple devices

### DIFF
--- a/Code/src/web/lib/auth.js
+++ b/Code/src/web/lib/auth.js
@@ -196,7 +196,7 @@ router.post('/login',
     }
 
     console.log("Session:" + login_redirect);
-    if(login_redirect!==null){
+  if(login_redirect!==null&&login_redirect.indexOf('.') == -1){
       res.redirect(config.appURL+login_redirect);}
     else
       res.redirect('/bolo' || '/');


### PR DESCRIPTION
Update routing at login to avoid breaking the navigation when links are saved as pictures on Apple devices
